### PR TITLE
Upgrade qemu and buildx actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,10 +48,10 @@ runs:
         GITHUB_ACTION_PATH: ${{ github.action_path }}
 
     # TODO should detect if qemu is needed based on current vs target platform
-    - uses: docker/setup-qemu-action@v3
+    - uses: docker/setup-qemu-action@v4
       if: inputs.platforms != ''
 
-    - uses: docker/setup-buildx-action@v3
+    - uses: docker/setup-buildx-action@v4
 
     - run: entrypoint.sh
       shell: bash


### PR DESCRIPTION
Just made a quick PR to bump these actions to their latest release, since the current versions use Node.js 20, which is deprecated on GitHub Actions (pops up in a warning when the actions run). 

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/